### PR TITLE
Feature/access counter

### DIFF
--- a/WorldwideTV.xcodeproj/project.pbxproj
+++ b/WorldwideTV.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		DB1DA6E21C616E4C005979C1 /* AutomaticSortManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB1DA6E11C616E4C005979C1 /* AutomaticSortManager.swift */; };
 		DBA46E2E1C5BA15B00146A27 /* WWChannels.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA46E2D1C5BA15B00146A27 /* WWChannels.swift */; };
 		DBB464131C5C22530067EC33 /* TVFetcherService.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBB464121C5C22530067EC33 /* TVFetcherService.swift */; };
+		E627ED871CBF82D800B31045 /* channels.json in Resources */ = {isa = PBXBuildFile; fileRef = E627ED861CBF82D800B31045 /* channels.json */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -70,6 +71,7 @@
 		DB56EF991C5C5185009E4900 /* Kingfisher.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Kingfisher.framework; path = Carthage/Build/tvOS/Kingfisher.framework; sourceTree = "<group>"; };
 		DBA46E2D1C5BA15B00146A27 /* WWChannels.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WWChannels.swift; sourceTree = "<group>"; };
 		DBB464121C5C22530067EC33 /* TVFetcherService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TVFetcherService.swift; sourceTree = "<group>"; };
+		E627ED861CBF82D800B31045 /* channels.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = channels.json; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -108,6 +110,7 @@
 		B3AA17BE1C5D3F5400202D1B /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				E627ED861CBF82D800B31045 /* channels.json */,
 				B3F7C2A21C5AE71D009298BA /* Assets.xcassets */,
 				B3AA17B71C5D3D4B00202D1B /* Images */,
 			);
@@ -292,6 +295,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B3F7C2A31C5AE71D009298BA /* Assets.xcassets in Resources */,
+				E627ED871CBF82D800B31045 /* channels.json in Resources */,
 				B3AA17BB1C5D3D5700202D1B /* vital_co.lsr in Resources */,
 				B3AA17BD1C5D3DA800202D1B /* startup.png in Resources */,
 			);
@@ -324,8 +328,8 @@
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = "/usr/local/bin/carthage copy-frameworks";
-			shellScript = "";
+			shellPath = /bin/sh;
+			shellScript = "/usr/local/bin/carthage copy-frameworks";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/WorldwideTV/AutomaticSortManager.swift
+++ b/WorldwideTV/AutomaticSortManager.swift
@@ -26,12 +26,23 @@ class AutomaticSortManager {
         Defaults[.launchCount]+=1
     }
     
-    func sumChannel(country: String, channel: String) {
-        // todo
+    func sumChannel(channel: String, ofCountry country: String) {
+        let key = keyForCountOfChannel(channel, ofCountry: country)
+        var accesses = Defaults.integerForKey(key)
+        accesses += 1
+        Defaults.setInteger(accesses, forKey: key)
     }
     
-    func getChannelCount(country: String, channel: String) {
-        // todo
+    func getChannelCount(channel: String, ofCountry country: String) -> Int {
+        return Defaults.integerForKey(keyForCountOfChannel(channel, ofCountry: country))
+    }
+    
+    func deleteChannelCount(channel: String, ofCountry country: String) {
+        Defaults.remove(keyForCountOfChannel(channel, ofCountry: country))
+    }
+    
+    private func keyForCountOfChannel(channel: String, ofCountry country: String) -> String {
+        return "Count-" + country + "-" + channel
     }
     
     

--- a/WorldwideTV/ChannelsListViewController.swift
+++ b/WorldwideTV/ChannelsListViewController.swift
@@ -8,6 +8,8 @@ private let cellReuseIdentifier = "cellReuseIdentifier"
 
 class ChannelsListViewController: UIViewController, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
     
+    var country: String!
+    
     var channels: [WWChannel]? {
         didSet {
             channelsCollectionView.reloadData()
@@ -91,7 +93,7 @@ class ChannelsListViewController: UIViewController, UICollectionViewDataSource, 
         let channel = channels![indexPath.row]
         
         if let url = NSURL(string: channel.url) {
-            let videoController = VideoPlayerController(url: url)
+            let videoController = VideoPlayerController(url: url, channel: channel.title, country: self.country)
             print("I TAPPED on \(channel.title)")
             presentViewController(videoController, animated: true, completion: .None)
         }

--- a/WorldwideTV/CountriesViewController.swift
+++ b/WorldwideTV/CountriesViewController.swift
@@ -77,6 +77,7 @@ class CountriesViewController: UIViewController, UITableViewDataSource {
     }
     
     func setChannelsForCountry(country: WWCountry) {
+        detailsViewController?.country = country.title
         detailsViewController?.channels = country.channels
     }
     

--- a/WorldwideTV/TVFetcherService.swift
+++ b/WorldwideTV/TVFetcherService.swift
@@ -12,8 +12,15 @@ import Argo
 class TVFetcherService {
     
     let CHANNELS_URL: String = "https://raw.githubusercontent.com/WorldwideTV/TVChannels/master/channels.json"
+    
+    let USE_REMOTE_LIST: Bool = true
 
     var countries: [WWCountry]?
+    
+    private var channelsUrl : String {
+        return self.USE_REMOTE_LIST ? CHANNELS_URL :
+            NSBundle.mainBundle().URLForResource("channels", withExtension: "json")!.absoluteString
+    }
     
     class var sharedInstance : TVFetcherService {
         struct Singleton {
@@ -23,7 +30,9 @@ class TVFetcherService {
     }
     
     func getChannelData(onCompletion: [WWCountry]? -> ()) {
-        Alamofire.request(.GET, CHANNELS_URL)
+        let channelsUrl = self.channelsUrl
+        NSLog("Getting channels from \(channelsUrl)")
+        Alamofire.request(.GET, channelsUrl)
             .responseJSON { response in
                 let json = try? NSJSONSerialization.JSONObjectWithData(response.data!, options: [])
                 

--- a/WorldwideTV/VideoPlayerController.swift
+++ b/WorldwideTV/VideoPlayerController.swift
@@ -4,9 +4,13 @@ import AVKit
 class VideoPlayerController: UIViewController {
     
     let url: NSURL
+    let channel: String
+    let country: String
 
-    init(url: NSURL) {
+    init(url: NSURL, channel: String, country: String) {
         self.url = url
+        self.channel = channel
+        self.country = country
         super.init(nibName: .None, bundle: .None)
     }
 
@@ -16,6 +20,8 @@ class VideoPlayerController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        AutomaticSortManager.sharedInstance.sumChannel(self.channel, ofCountry: self.country)
         
         let player = AVPlayer(URL: url)
         let playerController = AVPlayerViewController()

--- a/WorldwideTV/channels.json
+++ b/WorldwideTV/channels.json
@@ -1,0 +1,104 @@
+{
+  "countries": [
+    {
+      "title": "Portugal",
+      "channels": [
+        {
+          "title": "RTP 1",
+          "url": "http://rtp-pull-live.hls.adaptive.level3.net/liverepeater/smil:rtp1.smil/playlist.m3u8",
+          "thumbnail": "https://raw.githubusercontent.com/WorldwideTV/TVChannels/master/images/bbc1.jpg"
+        },
+        {
+          "title": "RTP 2",
+          "url": "http://rtp-pull-live.hls.adaptive.level3.net/liverepeater/smil:rtp2.smil/playlist.m3u8",
+          "thumbnail": "https://raw.githubusercontent.com/WorldwideTV/TVChannels/master/images/bbc3.gif"
+        },
+        {
+          "title": "RTP 3",
+          "url": "http://rtp-pull-live.hls.adaptive.level3.net/liverepeater/rtpn_5ch64h264.stream/chunklist.m3u8",
+          "thumbnail": "https://raw.githubusercontent.com/WorldwideTV/TVChannels/master/images/bbc1.jpg"
+        },
+        {
+          "title": "TVI",
+          "url": "http://video-live.iol.pt:1935/live_tvi/smil:LIVE_TVI/playlist.m3u8",
+          "thumbnail": "https://raw.githubusercontent.com/WorldwideTV/TVChannels/master/images/bbc2.gif"
+        },
+        {
+          "title": "RTP Memória",
+          "url": "http://rtp-pull-live.hls.adaptive.level3.net/liverepeater/rtpmem_5ch80h264.stream/chunklist.m3u8",
+          "thumbnail": "https://raw.githubusercontent.com/WorldwideTV/TVChannels/master/images/bbc1.jpg"
+        },
+        {
+          "title": "RTP Internacional",
+          "url": "http://rtp-pull-live.hls.adaptive.level3.net/liverepeater/smil:rtpi.smil/inspirationlinks.m3u8",
+          "thumbnail": "https://raw.githubusercontent.com/WorldwideTV/TVChannels/master/images/bbc2.gif"
+        },
+        {
+          "title": "TVI 24",
+          "url": "http://video-live.iol.pt:1935/live_tvi24/smil:LIVE_TVI24/inspirationlinks.m3u8",
+          "thumbnail": "https://raw.githubusercontent.com/WorldwideTV/TVChannels/master/images/bbc4.jpg"
+        }
+      ]
+    },
+    {
+      "title": "United Kingdom",
+      "channels": [
+        {
+          "title": "UK 1",
+          "url": "http://rtp-pull-live.hls.adaptive.level3.net/liverepeater/smil:rtp1.smil/playlist.m3u8",
+          "thumbnail": "https://raw.githubusercontent.com/WorldwideTV/TVChannels/master/images/bbc2.gif"
+        },
+        {
+          "title": "UK 2",
+          "url": "http://rtp-pull-live.hls.adaptive.level3.net/liverepeater/smil:rtp2.smil/playlist.m3u8",
+          "thumbnail": "https://raw.githubusercontent.com/WorldwideTV/TVChannels/master/images/bbc1.jpg"
+        }
+      ]
+    },
+    {
+      "title": "Spain",
+      "channels": [
+        {
+          "title": "Spain 1",
+          "url": "http://rtp-pull-live.hls.adaptive.level3.net/liverepeater/smil:rtp1.smil/playlist.m3u8",
+          "thumbnail": "https://raw.githubusercontent.com/WorldwideTV/TVChannels/master/images/bbc1.jpg"
+        },
+        {
+          "title": "Spain 2",
+          "url": "http://rtp-pull-live.hls.adaptive.level3.net/liverepeater/smil:rtp2.smil/playlist.m3u8",
+          "thumbnail": "https://raw.githubusercontent.com/WorldwideTV/TVChannels/master/images/bbc1.jpg"
+        }
+      ]
+    },
+    {
+      "title": "Canada",
+      "channels": [
+        {
+          "title": "Canada 1",
+          "url": "http://rtp-pull-live.hls.adaptive.level3.net/liverepeater/smil:rtp1.smil/playlist.m3u8",
+          "thumbnail": "https://raw.githubusercontent.com/WorldwideTV/TVChannels/master/images/bbc1.jpg"
+        },
+        {
+          "title": "Canada 2",
+          "url": "http://rtp-pull-live.hls.adaptive.level3.net/liverepeater/smil:rtp2.smil/playlist.m3u8",
+          "thumbnail": "https://raw.githubusercontent.com/WorldwideTV/TVChannels/master/images/bbc4.jpg"
+        }
+      ]
+    },
+    {
+      "title": "Ukrain",
+      "channels": [
+        {
+          "title": "Ukrain 1",
+          "url": "http://rtp-pull-live.hls.adaptive.level3.net/liverepeater/smil:rtp1.smil/playlist.m3u8",
+          "thumbnail": "https://raw.githubusercontent.com/WorldwideTV/TVChannels/master/images/bbc4.jpg"
+        },
+        {
+          "title": "Ukrain 2",
+          "url": "http://rtp-pull-live.hls.adaptive.level3.net/liverepeater/smil:rtp2.smil/playlist.m3u8",
+          "thumbnail": "https://raw.githubusercontent.com/WorldwideTV/TVChannels/master/images/bbc4.jpg"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
- This can be used to enable features relying on the number of accesses to channels
- Channels accesses are kept in NSUserDefaults
- Count is done in VideoPlayer as there may be multiple entry points
  (from channel list or top shelf, for instance)
